### PR TITLE
Add support for arbitrary date selection.

### DIFF
--- a/nasa_background.py
+++ b/nasa_background.py
@@ -5,8 +5,7 @@ from tools.utils import parse_str_to_date
 
 
 @click.group()
-@click.option("--date", default=None, help="Enter the date as a single string in YYYYMMDD or YYYY-MM-DD format,
-              " or any other format where the numbers are seperated by an arbitrary seperator.")
+@click.option("--date", default=None, help="Enter the date as a single string in YYYYMMDD or YYYY-MM-DD format.")
 @click.pass_context
 def nasa_background(ctx, date):
     from datetime import datetime
@@ -30,9 +29,10 @@ def update(ctx):
         if click.confirm("Do you wish to download this image and set it as background?"):
             file_path = nasa_api.download_image(ctx.obj["DATE"])
             background.change_background(file_path)
-
+    except KeyError:
+        click.echo(f"Image not found for the selected date {ctx.obj['DATE']}. ")
     except Exception as e:
-        click.echo("Fatal error encountered, exiting program..")
+        click.echo("Fatal error encountered, exiting program.")
         click.echo(e)
 
 

--- a/nasa_background.py
+++ b/nasa_background.py
@@ -5,32 +5,31 @@ from tools.utils import parse_str_to_date
 
 
 @click.group()
+def nasa_background():
+    pass
+
+
+@nasa_background.command()
 @click.option("--date", default=None, help="Enter the date as a single string in YYYYMMDD or YYYY-MM-DD format.")
-@click.pass_context
-def nasa_background(ctx, date):
+def update(date):
     from datetime import datetime
+
     if date is None:
         date = datetime.now()
     else:
         date = parse_str_to_date(date)
     print(date)
-    ctx.obj = {"DATE": date}
-
-
-@nasa_background.command()
-@click.pass_context
-def update(ctx):
     '''Get the newest NASA Picture of the Day and set it as background'''
     try:
-        meta_info = nasa_api.get_info(ctx.obj["DATE"])
+        meta_info = nasa_api.get_info(date)
         click.echo(f"Title: {meta_info['title']}\n")
         click.echo(meta_info['explanation'] + "\n")
 
         if click.confirm("Do you wish to download this image and set it as background?"):
-            file_path = nasa_api.download_image(ctx.obj["DATE"])
+            file_path = nasa_api.download_image(date)
             background.change_background(file_path)
     except KeyError:
-        click.echo(f"Image not found for the selected date {ctx.obj['DATE']}. ")
+        click.echo(f"Image not found for the selected date {date}. ")
     except Exception as e:
         click.echo("Fatal error encountered, exiting program.")
         click.echo(e)

--- a/nasa_background.py
+++ b/nasa_background.py
@@ -18,7 +18,7 @@ def update(date):
         date = datetime.now()
     else:
         date = parse_str_to_date(date)
-    print(date)
+    
     '''Get the newest NASA Picture of the Day and set it as background'''
     try:
         meta_info = nasa_api.get_info(date)

--- a/nasa_background.py
+++ b/nasa_background.py
@@ -1,22 +1,32 @@
 import click
 
 from tools import nasa_api, background
+from tools.utils import parse_str_to_date
 
 
 @click.group()
-def nasa_background():
-    pass
+@click.option("--date", default=None, help="Enter the date as a single string in YYYY-MM-DD format.")
+@click.pass_context
+def nasa_background(ctx, date):
+    from datetime import datetime
+    if date is None:
+        date = datetime.now()
+    else:
+        date = parse_str_to_date(date)
+    ctx.obj = {"DATE": date}
+
 
 @nasa_background.command()
-def update():
+@click.pass_context
+def update(ctx):
     '''Get the newest NASA Picture of the Day and set it as background'''
     try:
-        meta_info = nasa_api.get_info()
+        meta_info = nasa_api.get_info(ctx.obj["DATE"])
         click.echo(f"Title: {meta_info['title']}\n")
         click.echo(meta_info['explanation'] + "\n")
 
         if click.confirm("Do you wish to download this image and set it as background?"):
-            file_path = nasa_api.download_image()
+            file_path = nasa_api.download_image(ctx.obj["DATE"])
             background.change_background(file_path)
 
     except Exception as e:

--- a/nasa_background.py
+++ b/nasa_background.py
@@ -5,7 +5,8 @@ from tools.utils import parse_str_to_date
 
 
 @click.group()
-@click.option("--date", default=None, help="Enter the date as a single string in YYYY-MM-DD format.")
+@click.option("--date", default=None, help="Enter the date as a single string in YYYYMMDD or YYYY-MM-DD format,
+              " or any other format where the numbers are seperated by an arbitrary seperator.")
 @click.pass_context
 def nasa_background(ctx, date):
     from datetime import datetime
@@ -13,6 +14,7 @@ def nasa_background(ctx, date):
         date = datetime.now()
     else:
         date = parse_str_to_date(date)
+    print(date)
     ctx.obj = {"DATE": date}
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
-`from tools.utils import parse_str_to_date
+from tools.utils import parse_str_to_date
 from datetime import datetime
-
 
 
 def test_parse_str_to_date_short():
@@ -30,9 +29,10 @@ def test_parse_str_to_date_minified():
 def test_parse_str_to_date_extra():
     assert parse_str_to_date("2019-7-6-9-12-3-34-5-1") == datetime(2019, 7, 6)
 
+
 if __name__ == "__main__":
     test_parse_str_to_date_short()
     test_parse_str_to_date_incomplete()
     test_parse_str_to_date_full()
     test_parse_str_to_date_minified()
-    test_parse_str_to_date_extra()`
+    test_parse_str_to_date_extra()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+`from tools.utils import parse_str_to_date
+from datetime import datetime
+
+
+
+def test_parse_str_to_date_short():
+    try:
+        parse_str_to_date("190706")
+        assert 1 == 0
+    except Exception as e:
+        assert isinstance(e, ValueError), "Should throw value error on short string."
+
+
+def test_parse_str_to_date_incomplete():
+    try:
+        parse_str_to_date("2019-07")
+        assert 1 == 0
+    except Exception as e:
+        assert isinstance(e, ValueError), "Should throw value error on short string."
+
+
+def test_parse_str_to_date_full():
+    assert parse_str_to_date("20190706") == datetime(2019, 7, 6)
+
+
+def test_parse_str_to_date_minified():
+    assert parse_str_to_date("2019-7-6") == datetime(2019, 7, 6)
+
+
+def test_parse_str_to_date_extra():
+    assert parse_str_to_date("2019-7-6-9-12-3-34-5-1") == datetime(2019, 7, 6)
+
+if __name__ == "__main__":
+    test_parse_str_to_date_short()
+    test_parse_str_to_date_incomplete()
+    test_parse_str_to_date_full()
+    test_parse_str_to_date_minified()
+    test_parse_str_to_date_extra()`

--- a/tools/nasa_api.py
+++ b/tools/nasa_api.py
@@ -12,6 +12,7 @@ API_KEY = 'DEMO_KEY'
 if not os.path.exists(IMAGE_FOLDER):
     os.makedirs(IMAGE_FOLDER)
 
+
 def get_info(date=datetime.today()):
     """
     Downloads the meta-info about the picture of the day for specified date
@@ -50,6 +51,9 @@ def download_image(date=datetime.today()):
     try:
         # Download meta_info for url
         meta_info = get_info(date=date)
+        print(meta_info.keys())
+        if "hdurl" not in meta_info.keys():
+            raise KeyError("download_image: meta_info does not contain hdurl.")
         url = meta_info['hdurl']
 
         # Construct path to save image
@@ -72,6 +76,8 @@ def download_image(date=datetime.today()):
 
         return img_path
 
+    except KeyError as e:
+        raise e
     except Exception as e:
         click.echo(f"Could not download: {meta_info['title']}")
         raise e

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,0 +1,18 @@
+def parse_str_to_date(date):
+    """ Given a date which is a string, will attempt to parse it by first splitting the string on its non numeric characters,
+    and then by partitioning YYYYMMDD from the string. """
+    import re
+    from datetime import datetime
+    date_str_arr = list(filter(lambda x: x.isdigit(), re.split(r"(\d+)", date)))
+    if len(date_str_arr) != 3:
+        date_str = "".join(date_str_arr)
+        if len(date_str) != 8:
+            raise ValueError("Insufficient digits to reconstruct a YYYY-mm-dd date")
+        else:
+            date_str_arr.clear()
+            date_str_arr.append(date_str[:4])
+            date_str_arr.append(date_str[4:6])
+            date_str_arr.append(date_str[6:])
+
+    date = datetime.strptime("-".join(date_str_arr[:3]), "%Y-%m-%d")
+    return date

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,6 +1,4 @@
 def parse_str_to_date(date):
-    """ Given a date which is a string, will attempt to parse it by first splitting the string on its non numeric characters,
-    and then by partitioning YYYYMMDD from the string. """
     import re
     from datetime import datetime
     date_str_arr = list(filter(lambda x: x.isdigit(), re.split(r"(\d+)", date)))
@@ -13,6 +11,11 @@ def parse_str_to_date(date):
             date_str_arr.append(date_str[:4])
             date_str_arr.append(date_str[4:6])
             date_str_arr.append(date_str[6:])
+
+    strs = [None] * 3
+    strs[0] = date_str_arr[0].zfill(4)
+    strs[1] = date_str_arr[1].zfill(2)
+    strs[2] = date_str_arr[2].zfill(2)
 
     date = datetime.strptime("-".join(date_str_arr[:3]), "%Y-%m-%d")
     return date

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,8 +1,12 @@
 def parse_str_to_date(date):
+    """ Given some date as a string, will attempt to parse it to a date, if it can be split into
+    3 or more sections of numeric characters seperated by non-numeric characters. Otherwise, it will
+    check if there are exactly eight digits: if so, it will split the string into YYYYMMDD compontents.
+    Otherwise, it will fail. """
     import re
     from datetime import datetime
     date_str_arr = list(filter(lambda x: x.isdigit(), re.split(r"(\d+)", date)))
-    if len(date_str_arr) != 3:
+    if len(date_str_arr) < 3:
         date_str = "".join(date_str_arr)
         if len(date_str) != 8:
             raise ValueError("Insufficient digits to reconstruct a YYYY-mm-dd date")
@@ -11,11 +15,6 @@ def parse_str_to_date(date):
             date_str_arr.append(date_str[:4])
             date_str_arr.append(date_str[4:6])
             date_str_arr.append(date_str[6:])
-
-    strs = [None] * 3
-    strs[0] = date_str_arr[0].zfill(4)
-    strs[1] = date_str_arr[1].zfill(2)
-    strs[2] = date_str_arr[2].zfill(2)
 
     date = datetime.strptime("-".join(date_str_arr[:3]), "%Y-%m-%d")
     return date


### PR DESCRIPTION
It is now possible to call the script like so:

```
python nasa_background.py --date 2017-09-16 update
```

or

```
python nasa_background.py -d 20170916 update
```

or 

```
python nasa_background.py -d 2017-9-16 update
```

If 8 digits continuous digits are passed (eg. 20170916), it will parse as YYYYMMDD. If 3 numbers are passed as YYYY-M(M)-D(D) (eg. 2017-9-16 or 2017-09-16), it will pad the strings to sufficient length.
If more than 3 continuous numbers exist (eg. 2017-9-16-0) - it will ignore everything past the 3rd entry.

Resolves #7, #5 